### PR TITLE
update constructor so it is now being resolved easier

### DIFF
--- a/src/AutoProvider.php
+++ b/src/AutoProvider.php
@@ -29,14 +29,12 @@ class AutoProvider {
 
 	/**
 	 * @param Application $app
-	 * @param Repository  $config
-	 * @param Filesystem  $file
 	 */
-	public function __construct(Application $app, Repository $config, Filesystem $file)
+	public function __construct(Application $app)
 	{
 		$this->app = $app;
-		$this->config = $config;
-		$this->file = $file;
+		$this->config = $app['config'];
+		$this->file = $app['file']; 
 	}
 
 	/**


### PR DESCRIPTION
There is no need to inject full dependecies when we have the `Application` available, the app contains the IoC container. 
